### PR TITLE
fix(package): naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ go get github.com/jaredpalmer/ci-info
 ```go
 package main
 
-import ci "github.com/jaredpalmer/ci-info"
+import "github.com/jaredpalmer/ci-info"
 
 func main() {
   fmt.Println(ci.IsCi()) // true or false 

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 // A simple utilty to check if a program is being executed in common CI/CD/PaaS vendors. This is a partial port of https://github.com/watson/ci-info
-package main
+package ci
 
 import "os"
 

--- a/vendors.go
+++ b/vendors.go
@@ -1,4 +1,4 @@
-package main
+package ci
 
 // Vendor describes a CI/CD vendor execution environment
 type Vendor struct {


### PR DESCRIPTION
Avoids `import "github.com/jaredpalmer/ci-info" is a program, not an importable package` error from `go-golangci-lint` error, and also allows importing without requiring an alias.